### PR TITLE
PC-9974 - upload API client issue with Boto3

### DIFF
--- a/simplest/README.md
+++ b/simplest/README.md
@@ -24,6 +24,22 @@ pip install boto3
 9. The rest can be blank. Click "Create API Client" button.
 10. Note the created Client ID and Client Secret.
 
+### Configure S3 Client for Panopto Uploads
+Panopto's upload process involves interacting with an S3-compatible service. To maintain compatibility with this upload flow, the S3 client used in `boto3` must explicitly be set to use the `s3v4` signing protocol. This is a required configuration for correctly uploading to Panopto's S3-compatible upload targets.
+
+This configuration has already been implemented in the provided sample application, specifically in the `panopto_uploader.py` file. However, if you are encountering issues with upload failures, you should ensure that the S3 client is correctly initialized with the `Config(signature_version='s3v4')`.
+
+For example:
+
+s3 = boto3.session.Session().client(
+    service_name='s3',
+    endpoint_url=service_endpoint,  # Replace with your service endpoint
+    verify=self.ssl_verify,        	# SSL verification configuration
+    aws_access_key_id='dummy',     	# Dummy credentials
+    aws_secret_access_key='dummy', 	# Dummy credentials
+    config=boto3.session.Config(signature_version='s3v4')
+)
+
 ## Determine the target folder ID
 1. Navigate to the target folder on Panopto web site
 2. Click gear icon at the top-right corner.
@@ -45,6 +61,9 @@ Type ```python upload.py --help``` for more command line options.
 
 ### Warning
 This sample application intentionally does not include error handling or retry logic in order to focus on the usage of API. As the best practice, you should have both proper error handling and reasonable retry logic in production code.
+
+### Panopto Upload API and S3 Client Configuration
+The sample application is already configured to use the `s3v4` signing protocol when interacting with Panopto's upload services (see "### Configure S3 Client for Panopto Uploads" section). If you encounter any issues with upload failures, revisit that section for further details on this configuration.
 
 ### Capture traffic
 It is useful to capture the actual network traffic by the capture tool, like [Fiddler on Windows](https://www.telerik.com/fiddler) and [Charles on Mac](https://www.charlesproxy.com/), and examine it.

--- a/simplest/panopto_uploader.py
+++ b/simplest/panopto_uploader.py
@@ -137,7 +137,9 @@ class PanoptoUploader:
             endpoint_url = service_endpoint,
             verify = self.ssl_verify,
             aws_access_key_id='dummy',
-            aws_secret_access_key = 'dummy')
+            aws_secret_access_key = 'dummy',
+            config=boto3.session.Config(signature_version='s3v4')
+        )
         
         # Initiate multipart upload.
         mpu = s3.create_multipart_upload(Bucket = bucket, Key = object_key)


### PR DESCRIPTION
<!-- General Code Review Policy https://docs.google.com/document/d/1hrlA_6FOuhGDAGe1pepMB5Y6dHQ_55E0iR4sl8JleUc/edit --> 
<!-- UXE Code Review Policy https://docs.google.com/document/d/1tALmUckmYTi1he7NGpdQfEygFRISphT5tKP6oGccPVo/edit -->

## Description 
Added `Config(signature_version='s3v4')` to the S3 client initialization to enforce the v4 signing protocol. This ensures compatibility with the latest versions of Boto3 and Panopto's S3-compatible backend for multipart uploads.

## Testing
<!-- How and what have you tested? What needs later verification? -->
Uploaded the video file using python upload script

`python upload.py --server your.site.panopto.com --folder-id [Folder ID] --upload-file test.mp4 --client-id [Client ID] --client-secret [Client Secret]`

<img width="412" height="245" alt="image" src="https://github.com/user-attachments/assets/b624e41b-3476-4687-8b77-c7e34dc161ec" />

## Security or cross-site (customer data leak) concerns
n/a

## Cloud COGS Impact
<!-- If any, how will you measure? -->
n/a

## Jira Link
<!-- E.g. PC-### (link to Jira will populate automatically). Optional and Jira# must still be added to the PR title. -->
PC-9974